### PR TITLE
Adding send to python and retrieve from python

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### What is this? ###
 
-This repository contains OpenFOAM code and tutorials that show how to use Python interpreters to interact with OpenFOAM via pythonPal. pythonPal offers Python support and interoperability between the C++/Python data based on the pybind11 library [1]. The code in this repository is based on OpenFOAM-9, however, as noted below, the procedures are expected to compile with similar versions and forks of OpenFOAM.
+This repository contains OpenFOAM code and tutorials that show how to use Python interpreters to interact with OpenFOAM via pythonPal4foam (aka pythonPal), as presented by Rodriguez and Cardiff [1]. pythonPal offers Python support and interoperability between the C++/Python data based on the pybind11 library [2]. The code in this repository is based on OpenFOAM-9, however, as noted below, the procedures are expected to compile with similar versions and forks of OpenFOAM.
 
 ### How do I get set up? ###
 
@@ -73,5 +73,5 @@ If desired, the user can make the small changes required to get the cases to wor
 
 
 ### References ###
-
-[1]	W. Jakob, J. Rhinelander, and D. Moldovan, “pybind11 – Seamless operability between C++11 and Python.” 2017.
+[1] S. A. Rodriguez L. and P. Cardiff, \A general approach for running python codes in openfoam using an embedded pybind11 python interpreter,"OpenFOAM® Journal, vol. 2, p. 166{182, Dec. 2022. [Online]. Available: http://dx.doi.org/10.51560/ofj.v2.79
+[2]	W. Jakob, J. Rhinelander, and D. Moldovan, “pybind11 – Seamless operability between C++11 and Python.” 2017.

--- a/README.md
+++ b/README.md
@@ -74,4 +74,5 @@ If desired, the user can make the small changes required to get the cases to wor
 
 ### References ###
 [1] S. A. Rodriguez L. and P. Cardiff, \A general approach for running python codes in openfoam using an embedded pybind11 python interpreter,"OpenFOAM® Journal, vol. 2, p. 166{182, Dec. 2022. [Online]. Available: http://dx.doi.org/10.51560/ofj.v2.79
+
 [2]	W. Jakob, J. Rhinelander, and D. Moldovan, “pybind11 – Seamless operability between C++11 and Python.” 2017.


### PR DESCRIPTION
Added methods to send/retrieve scalars and words to Python side. 

Note that the pythonPalIcoFoam solver (included) tests all those methods, and they work. 

Also, updated the README.md file to include the paper by Rodriguez and Cardiff.